### PR TITLE
Added ability to filter out by date/time and DNS hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Development
+
+* Added the ability to filter out computers with properties older than a given number of days
+
 ## Release 0.1.0
 
 **Features**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,20 @@ All notable changes to this project will be documented in this file.
 ## Development
 
 * Added the ability to filter out computers with properties older than a given number of days
-
+  New parameters `filter_older_than_days` and `filter_older_attribute`.
+  
+  Contributed by Nick Maludy (@nmaludy Encore Technologies)
+  
+* Added the ability to ignore a set of hosts by their DNS hostname using the new parameter
+  `ignore_dns_hostnames`.
+  
+  Contributed by Nick Maludy (@nmaludy Encore Technologies)
+  
+* Added the ability to only return computers/hosts if they are a member of a given
+  AD group (by specifying the group's full `dn`) using the new property `member_of_group_dn`.
+  
+  Contributed by Nick Maludy (@nmaludy Encore Technologies)
+  
 ## Release 0.1.0
 
 **Features**

--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ groups:
         filter_older_than_days: 30
 ```
 
-### Example: Filter out computers by name
+### Example: Ignore computers by DNS hostname
 
 It's common that a computer may be returned from AD, but you have problems connecting to it.
 We provide the ability to filter out hosts, by name, coming form this plugin so you can get your work done.
-To accomplish this, we've provided the option `filter_dns_hostnames`. Simply pass in an array 
+To accomplish this, we've provided the option `ignore_dns_hostnames`. Simply pass in an array 
 of hostnames into this option, and any host matching that name will be excluded.
 
 ``` yaml
@@ -94,10 +94,31 @@ groups:
         domain_controller: '192.168.200.200'
         user: 'BOLT\\Administrator'
         password: 'Password1'
-        filter_dns_hostnames:
+        ignore_dns_hostnames:
           - mybadwinrm.bolt.local
           - mybaddc01.bolt.local
           - sccm03.bolt.local
+```
+
+### Example: Only return members of a given group
+
+It's common for AD admins to use groups for targetting. We provide the ability to 
+only return computers/hosts that are members of a specified group using the
+`member_of_group_dn` parameter. When passing a group to this parameter, you'll need to
+pass the full Distinguished Named (`dn`) of the group (example: `CN=Patching Group,OU=GPO Groups,OU=Groups,DC=domain,DC=tld,DC=tech`).
+
+``` yaml
+# inventory.yaml
+version: 2
+groups:
+  - name: patching_group_bolt_domain
+    targets:
+      - _plugin: ad_inventory
+        ad_domain: 'bolt.local'
+        domain_controller: '192.168.200.200'
+        user: 'BOLT\\Administrator'
+        password: 'Password1'
+        member_of_group_dn: 'CN=Patching Group,OU=GPO Groups,OU=Groups,DC=domain,DC=tld,DC=tech'
 ```
 
 ### What ad_inventory affects **OPTIONAL**

--- a/README.md
+++ b/README.md
@@ -49,20 +49,56 @@ groups:
       - _plugin: ad_inventory
         ad_domain: 'bolt.local'
         domain_controller: '192.168.200.200'
-        username: 'BOLT\\Administrator'
+        user: 'BOLT\\Administrator'
         password: 'Password1'
-
-        # tenant_id: xxxx-xxx-xxxx
-        # client_id: xxxx-xxx-xxxx
-        # client_secret: xxxx-xxx-xxxx
-        # subscription_id: xxxx-xxx-xxxx
-        # location: eastus
-        # resource_group: bolt
-        # tags:
-        #   foo: bar
-        #   baz: bak
 ```
 
+### Example: Filter out computers older than given number of days
+
+Sometimes in Active Directory land, computer objects are not removed. This plugin
+allows you to filter out objects older than a given number of days. 
+To do this there are two options available on the plugin:
+  * `filter_older_attribute` : This is the name of the LDAP attribute that contains a LDAP timestamp value that we'll use for filtering. Some good options here are `'pwdLastSet'` and `'lastLogonTimestamp'`.
+  * `filter_older_than_days` : Number of days (integer) that will be used as the cut-off point. If an object is older than this many days it will be filtered out of the results.
+
+``` yaml
+# inventory.yaml
+version: 2
+groups:
+  - name: all_bolt_domain
+    targets:
+      - _plugin: ad_inventory
+        ad_domain: 'bolt.local'
+        domain_controller: '192.168.200.200'
+        user: 'BOLT\\Administrator'
+        password: 'Password1'
+        filter_older_attribute: 'pwdLastSet'
+        filter_older_than_days: 30
+```
+
+### Example: Filter out computers by name
+
+It's common that a computer may be returned from AD, but you have problems connecting to it.
+We provide the ability to filter out hosts, by name, coming form this plugin so you can get your work done.
+To accomplish this, we've provided the option `filter_dns_hostnames`. Simply pass in an array 
+of hostnames into this option, and any host matching that name will be excluded.
+
+``` yaml
+# inventory.yaml
+version: 2
+groups:
+  - name: all_bolt_domain
+    targets:
+      - _plugin: ad_inventory
+        ad_domain: 'bolt.local'
+        domain_controller: '192.168.200.200'
+        user: 'BOLT\\Administrator'
+        password: 'Password1'
+        filter_dns_hostnames:
+          - mybadwinrm.bolt.local
+          - mybaddc01.bolt.local
+          - sccm03.bolt.local
+```
 
 ### What ad_inventory affects **OPTIONAL**
 

--- a/tasks/resolve_reference.json
+++ b/tasks/resolve_reference.json
@@ -36,9 +36,13 @@
       "description" : "LDAP attribute to use for filtering out old computers. Some good choices are pwdLastSet, lastLogonTimestamp",
       "type": "Optional[String]"
     },
-    "filter_dns_hostnames": {
-      "description" : "Array of computer DNS Hostnames to filter out.",
+    "ignore_dns_hostnames": {
+      "description" : "Array of computer DNS Hostnames to ignore. These hosts will be excluded from the results",
       "type": "Optional[Array[String]]"
+    },
+    "member_of_group_dn": {
+      "description" : "Only return computers that are members of this group. Please specify the grou by it's full Distinguished Name (DN)",
+      "type": "Optional[String]"
     }
   }
 }

--- a/tasks/resolve_reference.json
+++ b/tasks/resolve_reference.json
@@ -27,6 +27,18 @@
     "calculate_transport": {
       "description" : "TODO Defaults to true",
       "type": "Optional[Boolean]"
+    },
+    "filter_older_than_days": {
+      "description" : "Filter out computers that have a filter_property time older than this many days.",
+      "type": "Optional[Integer]"
+    },
+    "filter_older_attribute": {
+      "description" : "LDAP attribute to use for filtering out old computers. Some good choices are pwdLastSet, lastLogonTimestamp",
+      "type": "Optional[String]"
+    },
+    "filter_dns_hostnames": {
+      "description" : "Array of computer DNS Hostnames to filter out.",
+      "type": "Optional[Array[String]]"
     }
   }
 }


### PR DESCRIPTION
Started playing around with this plugin and there were two features missing that i needed:

### Ability to filter out old computers

In the AD environments we work in, it's common to have a bunch of very old computer objects. We wanted to filter out those objects by date/time using the `pwdLastSet` property. Instead of hard coding what property we used for the filter, we made it configurable with `filter_older_attribute`. The number of days we used for the filtering threshold is `filter_older_than_days`.

### Ability to filter out computers by hostname

We have problems when we get "all" of the computers. Sometimes the computers returned have problems and are inaccessible for whatever reason. We wanted to be able to filter out these hosts so we can get the rest of our work done, then come back to them later to fix. In order to facilitate this we've added a `filter_dns_hostnames` option that takes a list of hosts and excludes them from the results.