### PR TITLE
Added ability to filter out by date/time and DNS hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Development
+
+* Added the ability to filter out computers with properties older than a given number of days
+
 ## Release 0.1.0
 
 **Features**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## Development
 
-* Added the ability to filter out computers with properties older than a given number of days
-  New parameters `filter_older_than_days` and `filter_older_attribute`.
-  
-  Contributed by Nick Maludy (@nmaludy Encore Technologies)
-  
+* Added the ability to ignore computers with properties older than a given number of days
+  New parameters `ignore_older_than_days` and `ignore_older_than_attribute`.
+
+  Contributed by Nick Maludy ([@nmaludy](https://github.com/nmaludy) Encore Technologies)
+
 * Added the ability to ignore a set of hosts by their DNS hostname using the new parameter
   `ignore_dns_hostnames`.
-  
-  Contributed by Nick Maludy (@nmaludy Encore Technologies)
-  
+
+  Contributed by Nick Maludy ([@nmaludy](https://github.com/nmaludy) Encore Technologies)
+
 * Added the ability to only return computers/hosts if they are a member of a given
   AD group (by specifying the group's full `dn`) using the new property `member_of_group_dn`.
-  
-  Contributed by Nick Maludy (@nmaludy Encore Technologies)
-  
+
+  Contributed by Nick Maludy ([@nmaludy](https://github.com/nmaludy) Encore Technologies)
+
 ## Release 0.1.0
 
 **Features**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,20 @@ All notable changes to this project will be documented in this file.
 ## Development
 
 * Added the ability to filter out computers with properties older than a given number of days
-
+  New parameters `filter_older_than_days` and `filter_older_attribute`.
+  
+  Contributed by Nick Maludy (@nmaludy Encore Technologies)
+  
+* Added the ability to ignore a set of hosts by their DNS hostname using the new parameter
+  `ignore_dns_hostnames`.
+  
+  Contributed by Nick Maludy (@nmaludy Encore Technologies)
+  
+* Added the ability to only return computers/hosts if they are a member of a given
+  AD group (by specifying the group's full `dn`) using the new property `member_of_group_dn`.
+  
+  Contributed by Nick Maludy (@nmaludy Encore Technologies)
+  
 ## Release 0.1.0
 
 **Features**

--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ groups:
         filter_older_than_days: 30
 ```
 
-### Example: Filter out computers by name
+### Example: Ignore computers by DNS hostname
 
 It's common that a computer may be returned from AD, but you have problems connecting to it.
 We provide the ability to filter out hosts, by name, coming form this plugin so you can get your work done.
-To accomplish this, we've provided the option `filter_dns_hostnames`. Simply pass in an array 
+To accomplish this, we've provided the option `ignore_dns_hostnames`. Simply pass in an array 
 of hostnames into this option, and any host matching that name will be excluded.
 
 ``` yaml
@@ -94,10 +94,31 @@ groups:
         domain_controller: '192.168.200.200'
         user: 'BOLT\\Administrator'
         password: 'Password1'
-        filter_dns_hostnames:
+        ignore_dns_hostnames:
           - mybadwinrm.bolt.local
           - mybaddc01.bolt.local
           - sccm03.bolt.local
+```
+
+### Example: Only return members of a given group
+
+It's common for AD admins to use groups for targetting. We provide the ability to 
+only return computers/hosts that are members of a specified group using the
+`member_of_group_dn` parameter. When passing a group to this parameter, you'll need to
+pass the full Distinguished Named (`dn`) of the group (example: `CN=Patching Group,OU=GPO Groups,OU=Groups,DC=domain,DC=tld,DC=tech`).
+
+``` yaml
+# inventory.yaml
+version: 2
+groups:
+  - name: patching_group_bolt_domain
+    targets:
+      - _plugin: ad_inventory
+        ad_domain: 'bolt.local'
+        domain_controller: '192.168.200.200'
+        user: 'BOLT\\Administrator'
+        password: 'Password1'
+        member_of_group_dn: 'CN=Patching Group,OU=GPO Groups,OU=Groups,DC=domain,DC=tld,DC=tech'
 ```
 
 ### What ad_inventory affects **OPTIONAL**

--- a/README.md
+++ b/README.md
@@ -49,20 +49,56 @@ groups:
       - _plugin: ad_inventory
         ad_domain: 'bolt.local'
         domain_controller: '192.168.200.200'
-        username: 'BOLT\\Administrator'
+        user: 'BOLT\\Administrator'
         password: 'Password1'
-
-        # tenant_id: xxxx-xxx-xxxx
-        # client_id: xxxx-xxx-xxxx
-        # client_secret: xxxx-xxx-xxxx
-        # subscription_id: xxxx-xxx-xxxx
-        # location: eastus
-        # resource_group: bolt
-        # tags:
-        #   foo: bar
-        #   baz: bak
 ```
 
+### Example: Filter out computers older than given number of days
+
+Sometimes in Active Directory land, computer objects are not removed. This plugin
+allows you to filter out objects older than a given number of days. 
+To do this there are two options available on the plugin:
+  * `filter_older_attribute` : This is the name of the LDAP attribute that contains a LDAP timestamp value that we'll use for filtering. Some good options here are `'pwdLastSet'` and `'lastLogonTimestamp'`.
+  * `filter_older_than_days` : Number of days (integer) that will be used as the cut-off point. If an object is older than this many days it will be filtered out of the results.
+
+``` yaml
+# inventory.yaml
+version: 2
+groups:
+  - name: all_bolt_domain
+    targets:
+      - _plugin: ad_inventory
+        ad_domain: 'bolt.local'
+        domain_controller: '192.168.200.200'
+        user: 'BOLT\\Administrator'
+        password: 'Password1'
+        filter_older_attribute: 'pwdLastSet'
+        filter_older_than_days: 30
+```
+
+### Example: Filter out computers by name
+
+It's common that a computer may be returned from AD, but you have problems connecting to it.
+We provide the ability to filter out hosts, by name, coming form this plugin so you can get your work done.
+To accomplish this, we've provided the option `filter_dns_hostnames`. Simply pass in an array 
+of hostnames into this option, and any host matching that name will be excluded.
+
+``` yaml
+# inventory.yaml
+version: 2
+groups:
+  - name: all_bolt_domain
+    targets:
+      - _plugin: ad_inventory
+        ad_domain: 'bolt.local'
+        domain_controller: '192.168.200.200'
+        user: 'BOLT\\Administrator'
+        password: 'Password1'
+        filter_dns_hostnames:
+          - mybadwinrm.bolt.local
+          - mybaddc01.bolt.local
+          - sccm03.bolt.local
+```
 
 ### What ad_inventory affects **OPTIONAL**
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # ad_inventory
 
-Welcome to your new module. A short overview of the generated parts can be found in the PDK documentation at https://puppet.com/pdk/latest/pdk_generating_modules.html .
-
-The README template below provides a starting point with details about what information to include in your README.
+The ad_inventory Puppet Module is an [Inventory Plugin](https://puppet.com/docs/bolt/latest/using_plugins.html#ariaid-title2) for Bolt which can dynamically query Active Directory for target information.
 
 #### Table of Contents
 
@@ -31,6 +29,14 @@ On Windows
 > "C:/Program Files/Puppet Labs/Bolt/bin/gem.bat" install --user-install net-ldap
 ```
 
+On other platforms
+
+``` text
+> /opt/puppetlabs/bolt/bin/gem install --user-install net-ldap
+```
+
+Reference - [Bolt Documentation](https://puppet.com/docs/bolt/latest/bolt_installing.html#ariaid-title13)
+
 ### Development
 
 ``` text
@@ -42,6 +48,7 @@ On Windows
 ```
 
 Example Inventory
+
 ``` yaml
 # inventory.yaml
 version: 2
@@ -144,66 +151,3 @@ groups:
         password: 'Password1'
         member_of_group_dn: 'CN=Patching Group 1,OU=GPO Groups,OU=Groups,DC=bolt,DC=local'
 ```
-
-### What ad_inventory affects **OPTIONAL**
-
-If it's obvious what your module touches, you can skip this section. For example, folks can probably figure out that your mysql_instance module affects their MySQL instances.
-
-If there's more that they should know about, though, this is the place to mention:
-
-* Files, packages, services, or operations that the module will alter, impact, or execute.
-* Dependencies that your module automatically installs.
-* Warnings or other important notices.
-
-### Setup Requirements **OPTIONAL**
-
-If your module requires anything extra before setting up (pluginsync enabled, another module, etc.), mention it here.
-
-If your most recent release breaks compatibility or requires particular steps for upgrading, you might want to include an additional "Upgrading" section here.
-
-### Beginning with ad_inventory
-
-The very basic steps needed for a user to get the module up and running. This can include setup steps, if necessary, or it can be an example of the most basic use of the module.
-
-## Usage
-
-Include usage examples for common use cases in the **Usage** section. Show your users how to use your module to solve problems, and be sure to include code examples. Include three to five examples of the most important or common tasks a user can accomplish with your module. Show users how to accomplish more complex tasks that involve different types, classes, and functions working in tandem.
-
-## Reference
-
-This section is deprecated. Instead, add reference information to your code as Puppet Strings comments, and then use Strings to generate a REFERENCE.md in your module. For details on how to add code comments and generate documentation with Strings, see the Puppet Strings [documentation](https://puppet.com/docs/puppet/latest/puppet_strings.html) and [style guide](https://puppet.com/docs/puppet/latest/puppet_strings_style.html)
-
-If you aren't ready to use Strings yet, manually create a REFERENCE.md in the root of your module directory and list out each of your module's classes, defined types, facts, functions, Puppet tasks, task plans, and resource types and providers, along with the parameters for each.
-
-For each element (class, defined type, function, and so on), list:
-
-  * The data type, if applicable.
-  * A description of what the element does.
-  * Valid values, if the data type doesn't make it obvious.
-  * Default value, if any.
-
-For example:
-
-```
-### `pet::cat`
-
-#### Parameters
-
-##### `meow`
-
-Enables vocalization in your cat. Valid options: 'string'.
-
-Default: 'medium-loud'.
-```
-
-## Limitations
-
-In the Limitations section, list any incompatibilities, known issues, or other warnings.
-
-## Development
-
-In the Development section, tell other users the ground rules for contributing to your project and how they should submit their work.
-
-## Release Notes/Contributors/Etc. **Optional**
-
-If you aren't using changelog, put your release notes here (though you should consider using changelog). You can also add any additional sections you feel are necessary or important to include here. Please use the `## ` header.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ This should be a fairly short description helps the user decide if your module i
 
 Install net-ldap gem into Bolt
 
+On Windows
+
 ``` text
 > "C:/Program Files/Puppet Labs/Bolt/bin/gem.bat" install --user-install net-ldap
 ```
@@ -36,7 +38,7 @@ Install net-ldap gem into Bolt
 
 ...
 
-> bundle exec bolt command run "Write-host 'Hello'" --modulepath spec/fixtures/modules  --inventoryfile example_inventory.yaml
+> bundle exec bolt command run "Write-Host 'Hello'" --modulepath spec/fixtures/modules --inventoryfile example_inventory.yaml
 ```
 
 Example Inventory

--- a/example_inventory.yaml
+++ b/example_inventory.yaml
@@ -13,21 +13,3 @@ groups:
         user: "BOLT\\Administrator"
         password: "Password1"
         calculate_transport: false
-# config:
-#   winrm:
-#     username: "BOLT\\Administrator"
-#     password: Password1
-#     ssl: false
-
-        # tenant_id: xxxx-xxx-xxxx
-        # client_id: xxxx-xxx-xxxx
-        # client_secret: xxxx-xxx-xxxx
-        # subscription_id: xxxx-xxx-xxxx
-        # location: eastus
-        # resource_group: bolt
-        # tags:
-        #   foo: bar
-        #   baz: bak
-
-# be bolt command run "Write-host 'Hello'" --debug --targets all_bolt_domain --inventoryfile .\example_inventory.yaml --modulepath .\spec\fixtures\modules\
-# be bolt command run "Write-host 'Hello'" --target 192.168.200.200 --transport=winrm --no-ssl --user Bolt\Administrator --password Password1

--- a/tasks/resolve_reference.json
+++ b/tasks/resolve_reference.json
@@ -36,9 +36,13 @@
       "description" : "LDAP attribute to use for filtering out old computers. Some good choices are pwdLastSet, lastLogonTimestamp",
       "type": "Optional[String]"
     },
-    "filter_dns_hostnames": {
-      "description" : "Array of computer DNS Hostnames to filter out.",
+    "ignore_dns_hostnames": {
+      "description" : "Array of computer DNS Hostnames to ignore. These hosts will be excluded from the results",
       "type": "Optional[Array[String]]"
+    },
+    "member_of_group_dn": {
+      "description" : "Only return computers that are members of this group. Please specify the grou by it's full Distinguished Name (DN)",
+      "type": "Optional[String]"
     }
   }
 }

--- a/tasks/resolve_reference.json
+++ b/tasks/resolve_reference.json
@@ -28,12 +28,12 @@
       "description" : "TODO Defaults to true",
       "type": "Optional[Boolean]"
     },
-    "filter_older_than_days": {
-      "description" : "Filter out computers that have a filter_property time older than this many days.",
-      "type": "Optional[Integer]"
+    "ignore_older_than_days": {
+      "description" : "Ignore computers that have a ignore_older_than_attribute time older than this many days.",
+      "type": "Optional[Integer[1]]"
     },
-    "filter_older_attribute": {
-      "description" : "LDAP attribute to use for filtering out old computers. Some good choices are pwdLastSet, lastLogonTimestamp",
+    "ignore_older_than_attribute": {
+      "description" : "LDAP attribute to use for ignoring old computers. Common attributes are pwdLastSet or lastLogonTimestamp",
       "type": "Optional[String]"
     },
     "ignore_dns_hostnames": {
@@ -41,7 +41,7 @@
       "type": "Optional[Array[String]]"
     },
     "member_of_group_dn": {
-      "description" : "Only return computers that are members of this group. Please specify the grou by it's full Distinguished Name (DN)",
+      "description" : "Only return computers that are members a group. This is full Distinguished Name (DN)",
       "type": "Optional[String]"
     }
   }

--- a/tasks/resolve_reference.json
+++ b/tasks/resolve_reference.json
@@ -27,6 +27,18 @@
     "calculate_transport": {
       "description" : "TODO Defaults to true",
       "type": "Optional[Boolean]"
+    },
+    "filter_older_than_days": {
+      "description" : "Filter out computers that have a filter_property time older than this many days.",
+      "type": "Optional[Integer]"
+    },
+    "filter_older_attribute": {
+      "description" : "LDAP attribute to use for filtering out old computers. Some good choices are pwdLastSet, lastLogonTimestamp",
+      "type": "Optional[String]"
+    },
+    "filter_dns_hostnames": {
+      "description" : "Array of computer DNS Hostnames to filter out.",
+      "type": "Optional[Array[String]]"
     }
   }
 }

--- a/tasks/resolve_reference.rb
+++ b/tasks/resolve_reference.rb
@@ -133,15 +133,5 @@ class ActiveDirectoryInventory < TaskHelper
 end
 
 if $PROGRAM_NAME == __FILE__
-  # TODO: DEBUG
-  if (__dir__.start_with?('C:/Source/'))
-    puts ActiveDirectoryInventory.new.task({
-      :ad_domain => 'bolt.local',
-      :domain_controller => '192.168.200.200',
-      :user => 'BOLT\\Administrator',
-      :password => 'Password1',
-    })
-    return
-  end
   ActiveDirectoryInventory.run
 end


### PR DESCRIPTION
Started playing around with this plugin and there were two features missing that i needed:

### Ability to filter out old computers

In the AD environments we work in, it's common to have a bunch of very old computer objects. We wanted to filter out those objects by date/time using the `pwdLastSet` property. Instead of hard coding what property we used for the filter, we made it configurable with `filter_older_attribute`. The number of days we used for the filtering threshold is `filter_older_than_days`.

### Ability to filter out computers by hostname

We have problems when we get "all" of the computers. Sometimes the computers returned have problems and are inaccessible for whatever reason. We wanted to be able to filter out these hosts so we can get the rest of our work done, then come back to them later to fix. In order to facilitate this we've added a `filter_dns_hostnames` option that takes a list of hosts and excludes them from the results.